### PR TITLE
Update home page with API data

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import axios from "axios";
 import { HeaderContainer, StyledNavLink } from "./styles";
 import { FaBars, FaTimes } from "react-icons/fa";
 import MobileMenu from "./mobile";
@@ -9,6 +10,7 @@ export const Header = () => {
   const [showLinks, setShowLinks] = useState(false);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const [userEmail, setUserEmail] = useState("");
+  const [editalLink, setEditalLink] = useState<string>("#");
   const emailFromLocalStorage = localStorage.getItem("token");
   const closeMenu = () => {
     setShowLinks(false);
@@ -33,6 +35,16 @@ export const Header = () => {
     };
 
     checkUserAuthentication();
+
+    axios
+      .get(
+        "https://api.jogajuntoinstituto.org/hotsite/selective/?process_id=5"
+      )
+      .then((response) => {
+        const result = response.data.results[0];
+        setEditalLink(result.edital);
+      })
+      .catch((err) => console.error(err));
 
     window.addEventListener("resize", handleResize);
 
@@ -63,6 +75,15 @@ export const Header = () => {
               Inscrição
             </StyledNavLink>
           )}  */}
+          <li>
+            <a
+              style={{ textDecoration: "none", color: "#54993a" }}
+              href={editalLink}
+              target="_blank"
+            >
+              Transparência
+            </a>
+          </li>
           <li>
             <a
               style={{

--- a/src/components/header/mobile/index.tsx
+++ b/src/components/header/mobile/index.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
+import axios from "axios";
 import MyDropdown from "../profile";
 import { StyledNavLink } from "../styles";
 import { MobileMenuContainer } from "./styles";
 
 const MobileMenu = ({ closeMenu }: any) => {
   const [user, setUser] = useState<string | undefined>(undefined);
+  const [editalLink, setEditalLink] = useState<string>("#");
 
   useEffect(() => {
     const checkUserAuthentication = () => {
@@ -16,6 +18,16 @@ const MobileMenu = ({ closeMenu }: any) => {
     };
 
     checkUserAuthentication();
+
+    axios
+      .get(
+        "https://api.jogajuntoinstituto.org/hotsite/selective/?process_id=5"
+      )
+      .then((response) => {
+        const result = response.data.results[0];
+        setEditalLink(result.edital);
+      })
+      .catch((err) => console.error(err));
   }, []);
 
   return (
@@ -36,7 +48,11 @@ const MobileMenu = ({ closeMenu }: any) => {
                <li><a style={{
             textDecoration: 'none',
             color: '#f8fcf7'
-           }} href="https://wa.me/559198189000" target={"_blank"}>Ajuda</a></li> 
+           }} href={editalLink} target="_blank">Transparência</a></li>
+               <li><a style={{
+            textDecoration: 'none',
+            color: '#f8fcf7'
+           }} href="https://wa.me/559198189000" target={"_blank"}>Ajuda</a></li>
           <div style={{
               marginTop: '20px'
              }}>

--- a/src/components/modules/modules.tsx
+++ b/src/components/modules/modules.tsx
@@ -1,6 +1,10 @@
 import { FormationInfo, ModuleContainer } from "./styles";
 
-export const Modules = ({}) => {
+interface ModulesProps {
+  hours: number;
+}
+
+export const Modules = ({ hours }: ModulesProps) => {
   return (
     <div>
       <ModuleContainer>
@@ -58,7 +62,7 @@ export const Modules = ({}) => {
           <img src="/certificado.svg" alt="" />
         </div>
         <div className="content">
-          <h2>+ de 170 horas de formação</h2>
+          <h2>+ de {hours} horas de formação</h2>
           <p>
             E diversos workshops com especialistas em finanças, recursos
             humanos, projetos, inovação, preparação para o mercado de trabalho e

--- a/src/pages/home/components/FAQ/faq.tsx
+++ b/src/pages/home/components/FAQ/faq.tsx
@@ -17,7 +17,7 @@ type FAQProps = {
   faqs: FAQItem[];
 };
 
-const FAQ: React.FC<FAQProps> = ({ faqs }: any) => {
+const FAQList: React.FC<FAQProps> = ({ faqs }) => {
   const [selectedItem, setSelectedItem] = useState<number | null>(-1);
 
   const toggleItem = (index: number) => {
@@ -128,105 +128,11 @@ const FAQ: React.FC<FAQProps> = ({ faqs }: any) => {
   );
 };
 
-const FAQs: React.FC = () => {
-  const faqs: FAQItem[] = [
-    {
-      question: "O que é o Ilhabela tech",
-      answer:
-        "• É um programa da Prefeitura de Ilhabela em parceria com o <a target='_blank' href='https://www.jogajuntoinstituto.org/'>Instituto JogaJunto</a> que visa capacitar e incluir novos profissionais no mercado tecnológico por meio do conhecimento técnico.",
-    },
-    {
-      question: "Vagas:",
-      answer: [
-        "São disponibilizadas 30 vagas para o curso, com no mínimo 20 aprovados para formação da turma.",
-      ],
-    },
-    {
-      question:
-        "Não sou residente de Ilhabela, mas frequento a cidade. Posso fazer o curso?",
-      answer: [
-        "Sim, você pode fazer o curso desde que compareça presencialmente nas aulas. A frequência mínima é de 75% em sala de aula para obtenção do certificado.",
-      ],
-    },
-    {
-      question: "Preciso estar presencial para fazer o curso?",
-      answer: [
-        "Sim, a frequência mínima é de 75% em sala de aula para obtenção do certificado.",
-      ],
-    },
-    {
-      question: "Recebo um certificado no final do curso?",
-      answer: [
-        "Sim, você receberá certificado desde que tenha frequência de 75% em sala de aula e tenha entregue o projeto final.",
-      ],
-    },
-    {
-      question: "Quantos certificados posso receber?",
-      answer: [
-        "Um certificado para o curso de Analista de Dados desde que tenha cumprido todos os requisitos de aprovação.",
-      ],
-    },
-    {
-      question: "Critério de classificação:",
-      answer: [
-        "As 30 melhores classificações no teste de conhecimentos em informática básica.",
-      ],
-    },
-    {
-      question: "Critério de desempate:",
-      answer: [
-        "Beneficiário de programas sociais do Governo Federal",
-        "Maior tempo de experiência na área",
-        "Maior nota na etapa teórica",
-      ],
-    },
-    {
-      question: "Qual a frequência mínima para eu receber o certificado?",
-      answer: ["Frequência de 75% em sala de aula."],
-    },
-    {
-      question: "Preciso pagar para realizar o curso?",
-      answer: [
-        "Não, o curso é realizado pelo  em parceria com a Prefeitura de Ilhabela e é oferecido gratuitamente para todos os aprovados no processo seletivo.",
-      ],
-    },
-    {
-      question: "Eu preciso passar por todas as etapas do processo de seleção?",
-      answer: [
-        "Sim. Todos os candidatos devem passar por todas as etapas do processo de seleção. Caso alguma etapa não seja concluída, haverá desclassificação.",
-      ],
-    },
-    {
-      question: "Posso fazer o curso mesmo tendo mais de 24 anos?",
-      answer: [
-        "Sim, ainda que você tenha mais que 24 anos, você pode fazer o curso normalmente.",
-      ],
-    },
-    {
-      question: "Tenho menos que 17 anos, posso fazer o curso?",
-      answer: [
-        "A idade mínima para fazer o curso é de 16 anos completos.",
-      ],
-    },
-    {
-      question: "Vou fazer 16 anos durante o curso, posso fazer minha inscrição?",
-      answer: [
-        "Não. No momento da sua inscrição, você já precisa ter 16 anos.",
-      ],
-    },
-    
-    {
-      question: "Posso fazer o curso mesmo tendo estudado em escola particular?",
-      answer: [
-        "Sim, você pode fazer o curso normalmente.",
-      ],
-    },
-  ];
-
+const FAQs: React.FC<FAQProps> = ({ faqs }) => {
   return (
     <FAQContainer>
       <h1 className="title">FAQ (Perguntas Frequentes)</h1>
-      <FAQ faqs={faqs} />
+      <FAQList faqs={faqs} />
     </FAQContainer>
   );
 };

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import axios from "axios";
 import { CardOne } from "./components/card";
 import { CardTwo } from "./components/cardTwo";
 import StepsHome from "./components/steps";
@@ -65,9 +66,26 @@ export const HomePage = () => {
   const auth = localStorage.getItem("token");
   const [showText, setShowText] = useState(false);
   const emailFromLocalStorage = localStorage.getItem("token");
+  const [faqs, setFaqs] = useState<any[]>([]);
+  const [hours, setHours] = useState<number>(0);
+  const [editalLink, setEditalLink] = useState<string>("#");
   const setCookie = (name: string) => {
     document.cookie = name;
   };
+
+  useEffect(() => {
+    axios
+      .get(
+        "https://api.jogajuntoinstituto.org/hotsite/selective/?process_id=5"
+      )
+      .then((response) => {
+        const result = response.data.results[0];
+        setFaqs(result.faqs || []);
+        setHours(result.course?.hours || 0);
+        setEditalLink(result.edital);
+      })
+      .catch((err) => console.error(err));
+  }, []);
 
   useEffect(() => {
     const hasVisitedHomePage = localStorage.getItem("final");
@@ -239,13 +257,13 @@ export const HomePage = () => {
             gap: "2rem",
           }}
         >
-          <Modules />
+          <Modules hours={hours} />
         </div>
         <About>
           <h1>Como participar</h1>
           <StepsHome />
         </About>
-        <FAQs />
+        <FAQs faqs={faqs} />
         <Footer />
       </ContainerHome>
     </div>


### PR DESCRIPTION
## Summary
- fetch process data from endpoint
- update modules component to show hours dynamically
- make FAQ list dynamic from backend
- link Transparency menu option to edital
- expose same link in mobile menu

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c7ce1835c832d93d8d509d26395c9