### PR TITLE
Add update video section

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -14,6 +14,7 @@ import {
   ContainerCardLayouta,
   ContainerHome,
   ContainerTitle,
+  VideoSection,
   ModalHome,
 } from "./styles";
 import { Link } from "react-router-dom";
@@ -69,6 +70,7 @@ export const HomePage = () => {
   const [faqs, setFaqs] = useState<any[]>([]);
   const [hours, setHours] = useState<number>(0);
   const [editalLink, setEditalLink] = useState<string>("#");
+  const [updateVideo, setUpdateVideo] = useState<string>("");
   const setCookie = (name: string) => {
     document.cookie = name;
   };
@@ -83,6 +85,7 @@ export const HomePage = () => {
         setFaqs(result.faqs || []);
         setHours(result.course?.hours || 0);
         setEditalLink(result.edital);
+        setUpdateVideo(result.course?.update_video || "");
       })
       .catch((err) => console.error(err));
   }, []);
@@ -245,6 +248,12 @@ export const HomePage = () => {
             alt="icon"
           />
         </BannerContainer>
+
+        {updateVideo && (
+          <VideoSection>
+            <video src={updateVideo} controls />
+          </VideoSection>
+        )}
 
         <div
           style={{

--- a/src/pages/home/styles.ts
+++ b/src/pages/home/styles.ts
@@ -231,12 +231,13 @@ width: 100%;
 `;
 
 export const VideoSection = styled.div`
-  margin: 2rem 0;
+  margin: 2rem ;
   width: 100%;
   display: flex;
   justify-content: center;
   video {
-    max-width: 100%;
+    width: 100%;
+    max-width: 50%;
     height: auto;
   }
 `;

--- a/src/pages/home/styles.ts
+++ b/src/pages/home/styles.ts
@@ -226,7 +226,18 @@ width: 100%;
   img {
     max-width: 100%;
     height: fit-content;
- 
+
+  }
+`;
+
+export const VideoSection = styled.div`
+  margin: 2rem 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  video {
+    max-width: 100%;
+    height: auto;
   }
 `;
 export const About = styled.div`


### PR DESCRIPTION
## Summary
- fetch update_video from API
- add VideoSection styled component
- show update video below banner on home page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f67378404832db5b6e9fb7419403a